### PR TITLE
Android version update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.stripe:stripe-android:21.2.1'
+    implementation 'com.stripe:stripe-android:20.52.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.stripe:stripe-android:20.19.1' // keep this version for now, as later versions cause build issues
+    implementation 'com.stripe:stripe-android:21.2.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.1.0
+version: 4.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-stripe
@@ -15,4 +15,4 @@ name: titanium-stripe
 moduleid: ti.stripe
 guid: 8a8da6b4-4dab-4c18-9439-de2e14457a1c
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0


### PR DESCRIPTION
### Attention: will only work with  Ti 12.7.0+

Since the Material library update was just merged into the Ti SDK master I was able to compile this module with higher Swiper library:

[ti.stripe-android-4.0.0.zip](https://github.com/user-attachments/files/18140716/ti.stripe-android-4.0.0.zip)

I don't have a working setup but the example project starts fine but will show an error when pressing the button.

Note: when trying to use `21.2.1` it was compiling fine but the app will crash with this error:
> Unable to get provider androidx.startup.InitializationProvider: androidx.startup.StartupException

https://github.com/stripe/stripe-android/issues/9534 and https://github.com/stripe/stripe-android/issues/9711

Looks like we have to raise some other libraries: https://github.com/stripe/stripe-android/blob/master/CHANGELOG.md#20530---2024-10-21

fixes: https://github.com/hansemannn/titanium-stripe/issues/4