### PR TITLE
Android: update to latest stripe module

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.stripe:stripe-android:20.52.1'
+    implementation 'com.stripe:stripe-android:22.5.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.stripe:stripe-android:22.5.0'
+    implementation 'com.stripe:stripe-android:22.7.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.0
+version: 6.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-stripe
@@ -15,4 +15,4 @@ name: titanium-stripe
 moduleid: ti.stripe
 guid: 8a8da6b4-4dab-4c18-9439-de2e14457a1c
 platform: android
-minsdk: 12.7.0
+minsdk: 13.1.0


### PR DESCRIPTION
* Upgrade Stripe library to 22.7.0
* requires Titanium SDK 13.1.x

[ti.stripe-android-6.0.0.zip](https://github.com/user-attachments/files/25022198/ti.stripe-android-6.0.0.zip)


Only tested building an app an importing it. Don't have stripe setup to verify functionality. 